### PR TITLE
Make it work with rc gradle versions

### DIFF
--- a/src/main/java/org/moe/gradle/AbstractMoePlugin.java
+++ b/src/main/java/org/moe/gradle/AbstractMoePlugin.java
@@ -114,8 +114,9 @@ public abstract class AbstractMoePlugin implements Plugin<Project> {
     private void checkGradleVersion(Project project) {
         final String version = project.getGradle().getGradleVersion();
         final String[] components = version.split("\\.");
+        final String[] minorComponents = components[1].split("-");
         final int major = Integer.parseInt(components[0 /* Major */]);
-        final int minor = Integer.parseInt(components[1 /* Minor */]);
+        final int minor = Integer.parseInt(minorComponents[0 /* Minor */]);
         if (major > GRADLE_MIN_VERSION_MAJOR ||
                 (major == GRADLE_MIN_VERSION_MAJOR && minor >= GRADLE_MIN_VERSION_MINOR)) {
             return;


### PR DESCRIPTION
For versions like 
    gradle-4.0-rc-1

Applying the moe plugin crashes with the following stacktrace:

```java
Caused by: java.lang.NumberFormatException: For input string: "0-rc-1"
        at org.moe.gradle.AbstractMoePlugin.checkGradleVersion(AbstractMoePlugin.java:118)
        at org.moe.gradle.AbstractMoePlugin.apply(AbstractMoePlugin.java:90)
```

So simply separate the minor part of the version "0-rc-1" and get the string before the first "-".