### PR TITLE
Added the passphrase to the identity to prevent an auth fail message

### DIFF
--- a/src/main/java/org/moe/gradle/remote/ServerSettings.java
+++ b/src/main/java/org/moe/gradle/remote/ServerSettings.java
@@ -565,7 +565,7 @@ class ServerSettings {
         final String identity = get(IDENTITY_KEY);
         if (identity != null) {
             final File file = getFileWithProperty(project, identity);
-            jsch.addIdentity(file.getAbsolutePath());
+            jsch.addIdentity(file.getAbsolutePath(), getKeychainPass());
         }
 
         return jsch;


### PR DESCRIPTION
See https://discuss.multi-os-engine.org/t/connection-error-when-setting-up-remote-build/905 for full details.