### PR TITLE
Added the possibility to define custom native-image command line options.

### DIFF
--- a/src/main/java/org/moe/gradle/MoeExtension.java
+++ b/src/main/java/org/moe/gradle/MoeExtension.java
@@ -64,6 +64,9 @@ public class MoeExtension extends AbstractMoeExtension {
     public final RemoteBuildOptions remoteBuildOptions;
 
     @NotNull
+    public final NativeImageOptions nativeImage;
+
+    @NotNull
     private MoePlatform platform = MoePlatform.IOS;
 
     @Nullable
@@ -81,6 +84,7 @@ public class MoeExtension extends AbstractMoeExtension {
         this.actionsAndOutlets = instantiator.newInstance(UIActionsAndOutletsOptions.class);
         this.ipaExport = instantiator.newInstance(IpaExportOptions.class);
         this.remoteBuildOptions = instantiator.newInstance(RemoteBuildOptions.class);
+        this.nativeImage = instantiator.newInstance(NativeImageOptions.class);
     }
 
     void setup() {
@@ -131,6 +135,11 @@ public class MoeExtension extends AbstractMoeExtension {
     @IgnoreUnused
     public void remoteBuild(Action<RemoteBuildOptions> action) {
         Require.nonNull(action).execute(remoteBuildOptions);
+    }
+
+    @IgnoreUnused
+    public void nativeImage(Action<NativeImageOptions> action) {
+        Require.nonNull(action).execute(nativeImage);
     }
 
     @NotNull

--- a/src/main/java/org/moe/gradle/options/NativeImageOptions.java
+++ b/src/main/java/org/moe/gradle/options/NativeImageOptions.java
@@ -1,0 +1,23 @@
+package org.moe.gradle.options;
+
+import org.moe.gradle.anns.IgnoreUnused;
+import org.moe.gradle.anns.Nullable;
+
+public class NativeImageOptions {
+
+    /**
+     * Array of native-image command-line options
+     */
+    @Nullable
+    private String[] options;
+
+    @Nullable
+    public String[] getOptions() {
+        return options;
+    }
+
+    @IgnoreUnused
+    public void setOptions(@Nullable String[] options) {
+        this.options = options;
+    }
+}

--- a/src/main/kotlin/org/moe/gradle/tasks/NativeImage.kt
+++ b/src/main/kotlin/org/moe/gradle/tasks/NativeImage.kt
@@ -126,6 +126,19 @@ open class NativeImage : AbstractBaseTask() {
         this.reflectionConfigFiles = reflectionConfigFiles?.toSet()
     }
 
+    private var proxyConfigFiles: Set<Any>? = null
+
+    @InputFiles
+    @NotNull
+    fun getProxyConfigFiles(): ConfigurableFileCollection {
+        return project.files(getOrConvention(proxyConfigFiles, CONVENTION_PROXY_CONFIG_FILES))
+    }
+
+    @IgnoreUnused
+    fun setProxyConfigFiles(proxyConfigFiles: Collection<Any>?) {
+        this.proxyConfigFiles = proxyConfigFiles?.toSet()
+    }
+
     private var customOptions: Set<String>? = null
 
     @InputFiles
@@ -152,6 +165,7 @@ open class NativeImage : AbstractBaseTask() {
                 ),
                 jniConfigFiles = getJniConfigFiles().toSet(),
                 reflectionConfigFiles = getReflectionConfigFiles().toSet(),
+                proxyConfigFiles = getProxyConfigFiles().toSet(),
                 customOptions = getCustomOptions(),
                 outputDir = getSvmTmpDir().toPath(),
                 logFile = logFile,
@@ -253,6 +267,12 @@ open class NativeImage : AbstractBaseTask() {
                 testClassesProviderTaskDep?.reflectionConfigFile,
             ).toSet()
         }
+        addConvention(CONVENTION_PROXY_CONFIG_FILES) {
+            listOfNotNull(
+                    moeSDK.proxyConfigBaseFile,
+                    project.file("dynamic-proxies.json").takeIf { it.exists() && it.isFile }
+            ).toSet()
+        }
         addConvention(CONVENTION_CUSTOM_OPTIONS) {
             val list: List<String> = project.file("customConfig.cfg").takeIf { it.exists() && it.isFile }?.useLines { it.toList() } ?: emptyList()
             list.union(moeExtension.nativeImage.options?.toList() ?: emptyList())
@@ -268,6 +288,7 @@ open class NativeImage : AbstractBaseTask() {
         private const val CONVENTION_LLVM_OBJ_FILE = "LLVMObjFile"
         private const val CONVENTION_JNI_CONFIG_FILES = "jniConfigFiles"
         private const val CONVENTION_REFLECTION_CONFIG_FILES = "reflectionConfigFiles"
+        private const val CONVENTION_PROXY_CONFIG_FILES = "proxyConfigFiles"
         private const val CONVENTION_CUSTOM_OPTIONS = "customOptions"
 
     }

--- a/src/main/kotlin/org/moe/gradle/tasks/NativeImage.kt
+++ b/src/main/kotlin/org/moe/gradle/tasks/NativeImage.kt
@@ -139,17 +139,17 @@ open class NativeImage : AbstractBaseTask() {
         this.proxyConfigFiles = proxyConfigFiles?.toSet()
     }
 
-    private var customOptions: Set<String>? = null
+    private var customOptions: List<String>? = null
 
     @InputFiles
     @NotNull
-    fun getCustomOptions(): Set<String> {
-        return getOrConvention(customOptions, CONVENTION_CUSTOM_OPTIONS) ?: emptySet()
+    fun getCustomOptions(): List<String> {
+        return getOrConvention(customOptions, CONVENTION_CUSTOM_OPTIONS) ?: emptyList()
     }
 
     @IgnoreUnused
     fun setCustomOptions(customOptions: Collection<String>) {
-        this.customOptions = customOptions.toSet()
+        this.customOptions = customOptions.toList()
     }
 
     override fun run() {
@@ -275,7 +275,7 @@ open class NativeImage : AbstractBaseTask() {
         }
         addConvention(CONVENTION_CUSTOM_OPTIONS) {
             val list: List<String> = project.file("customConfig.cfg").takeIf { it.exists() && it.isFile }?.useLines { it.toList() } ?: emptyList()
-            list.union(moeExtension.nativeImage.options?.toList() ?: emptyList())
+            list.union(moeExtension.nativeImage.options?.toList() ?: emptyList()).toList()
         }
     }
 

--- a/src/main/kotlin/org/moe/gradle/tasks/NativeImage.kt
+++ b/src/main/kotlin/org/moe/gradle/tasks/NativeImage.kt
@@ -275,7 +275,7 @@ open class NativeImage : AbstractBaseTask() {
         }
         addConvention(CONVENTION_CUSTOM_OPTIONS) {
             val list: List<String> = project.file("customConfig.cfg").takeIf { it.exists() && it.isFile }?.useLines { it.toList() } ?: emptyList()
-            list.union(moeExtension.nativeImage.options?.toList() ?: emptyList()).toList()
+            list + (moeExtension.nativeImage.options ?: emptyList<String>())
         }
     }
 


### PR DESCRIPTION
There are two different ways. 
1. With a customConfig.cfg file in the root of the ios module directory. Different arguments are seperated by a new line.
2.  With a configuration in the build.gradle file. The different  arguments are part of an array. e.g.: moe.nativeimage.options = ['--option1', '--option2']