### PR TITLE
Add possibility to use resource-config.json file.

### DIFF
--- a/src/main/kotlin/org/moe/gradle/tasks/NativeImage.kt
+++ b/src/main/kotlin/org/moe/gradle/tasks/NativeImage.kt
@@ -139,6 +139,19 @@ open class NativeImage : AbstractBaseTask() {
         this.proxyConfigFiles = proxyConfigFiles?.toSet()
     }
 
+    private var resourceConfigFiles: Set<Any>? = null
+
+    @InputFiles
+    @NotNull
+    fun getResourceConfigFiles(): ConfigurableFileCollection {
+        return project.files(getOrConvention(resourceConfigFiles, CONVENTION_RESOURCE_CONFIG_FILES))
+    }
+
+    @IgnoreUnused
+    fun setResourceConfigFiles(resourceConfigFile: Collection<Any>?) {
+        this.resourceConfigFiles = resourceConfigFile?.toSet()
+    }
+
     private var customOptions: List<String>? = null
 
     @Input
@@ -166,6 +179,7 @@ open class NativeImage : AbstractBaseTask() {
                 jniConfigFiles = getJniConfigFiles().toSet(),
                 reflectionConfigFiles = getReflectionConfigFiles().toSet(),
                 proxyConfigFiles = getProxyConfigFiles().toSet(),
+                resourceConfigFile = getResourceConfigFiles().toSet(),
                 customOptions = getCustomOptions(),
                 outputDir = getSvmTmpDir().toPath(),
                 logFile = logFile,
@@ -273,6 +287,11 @@ open class NativeImage : AbstractBaseTask() {
                     project.file("dynamic-proxies.json").takeIf { it.exists() && it.isFile }
             ).toSet()
         }
+        addConvention(CONVENTION_RESOURCE_CONFIG_FILES) {
+            listOfNotNull(
+                project.file("resource-config.json").takeIf { it.exists() && it.isFile }
+            )
+        }
         addConvention(CONVENTION_CUSTOM_OPTIONS) {
             listOfNotNull(
                 // Read the project custom config file
@@ -297,6 +316,7 @@ open class NativeImage : AbstractBaseTask() {
         private const val CONVENTION_JNI_CONFIG_FILES = "jniConfigFiles"
         private const val CONVENTION_REFLECTION_CONFIG_FILES = "reflectionConfigFiles"
         private const val CONVENTION_PROXY_CONFIG_FILES = "proxyConfigFiles"
+        private const val CONVENTION_RESOURCE_CONFIG_FILES = "resourceConfigFiles"
         private const val CONVENTION_CUSTOM_OPTIONS = "customOptions"
 
     }


### PR DESCRIPTION
This consists of two pr's (multi-os-engine/moe-tools-substrate#2).
This adds the possibility to use a custom resource-config.json to collect the resources instead of the all matching regex. For most Apps this isn't really useful but for some Apps (maybe which uses many libraries) this can really reduce the App size. 

