### PR TITLE
Send GraalVM home to IDE

### DIFF
--- a/src/main/kotlin/org/moe/gradle/model/builder/GradlePluginModelBuilder.kt
+++ b/src/main/kotlin/org/moe/gradle/model/builder/GradlePluginModelBuilder.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Project
 import org.gradle.tooling.provider.model.ToolingModelBuilder
 import org.moe.gradle.AbstractMoeExtension
 import org.moe.gradle.MoeExtension
+import org.moe.gradle.MoePlugin
 import org.moe.gradle.model.GradlePluginModel
 import org.moe.gradle.model.impl.GradlePluginModelImpl
 import org.moe.gradle.model.impl.MOESdkPropertiesImpl
@@ -25,6 +26,11 @@ class GradlePluginModelBuilder : ToolingModelBuilder {
                 coreJar = sdk.coreJar.absolutePath,
                 platformJar = ext.platformJar?.absolutePath,
                 junitJar = sdk.getiOSJUnitJar().absolutePath,
+                graalHome = if (ext.plugin is MoePlugin) {
+                    ext.plugin.graalVM.home.toAbsolutePath().toString()
+                } else {
+                    null
+                }
             ),
             xcodeProperties = if (ext is MoeExtension) {
                 val xcode = ext.xcode

--- a/src/main/kotlin/org/moe/gradle/model/impl/MOESdkPropertiesImpl.kt
+++ b/src/main/kotlin/org/moe/gradle/model/impl/MOESdkPropertiesImpl.kt
@@ -8,4 +8,5 @@ data class MOESdkPropertiesImpl(
     override val coreJar: String,
     override val platformJar: String?,
     override val junitJar: String,
+    override val graalHome: String?,
 ) : MOESdkProperties, Serializable


### PR DESCRIPTION
I don't know whether this is the best way to do this.
I'm also not sure when the "MOESdkPlugin" is used and how the case should be handled. Currently it just falls back to the old behavior. 