### PR TITLE
Make serialization support as optional feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ moe {
         // whether code obfuscation is enabled. Ignored when `baseCfgFile` is specified. Default to `false`
         obfuscationEnabled = false
 
+        // whether serialization support is enabled. Ignored when `baseCfgFile` is specified. Default to `false`
+        serializationSupport = false
+      
         // exclude files from `-injars` config that will be processed by proguard
         excludeFiles = [
                 'META-INF/*.SF',

--- a/src/main/java/org/moe/gradle/options/ProGuardOptions.java
+++ b/src/main/java/org/moe/gradle/options/ProGuardOptions.java
@@ -24,6 +24,7 @@ public class ProGuardOptions {
     private int level = LEVEL_APP;
     private boolean minifyEnabled = true;
     private boolean obfuscationEnabled = false;
+    private boolean serializationSupport = false;
     @Nullable
     private Set<String> excludeFiles;
 
@@ -86,6 +87,15 @@ public class ProGuardOptions {
     @IgnoreUnused
     public void setObfuscationEnabled(boolean obfuscationEnabled) {
         this.obfuscationEnabled = obfuscationEnabled;
+    }
+
+    public boolean isSerializationSupport() {
+        return serializationSupport;
+    }
+
+    @IgnoreUnused
+    public void setSerializationSupport(boolean serializationSupport) {
+        this.serializationSupport = serializationSupport;
     }
 
     @Nullable

--- a/src/main/java/org/moe/gradle/tasks/ProGuard.java
+++ b/src/main/java/org/moe/gradle/tasks/ProGuard.java
@@ -81,6 +81,8 @@ public class ProGuard extends AbstractBaseTask {
     private static final String CONVENTION_MINIFY_ENABLED = "minifyEnabled";
     private static final String CONVENTION_OBFUSCATION_ENABLED = "obfuscationEnabled";
 
+    private static final String CONVENTION_SERIALIZATION_SUPPORT = "serializationSupport";
+
     private static final String MOE_PROGUARD_INJARS_PROPERTY = "moe.proguard.injars";
 
     @Nullable
@@ -224,6 +226,19 @@ public class ProGuard extends AbstractBaseTask {
     }
 
     @Nullable
+    private Boolean serializationSupport;
+
+    @IgnoreUnused
+    public void setSerializationSupport(Boolean serializationSupport) {
+        this.serializationSupport = serializationSupport;
+    }
+
+    @Input
+    public boolean isSerializationSupport() {
+        return getOrConvention(serializationSupport, CONVENTION_SERIALIZATION_SUPPORT);
+    }
+
+    @Nullable
     private Object mappingFile;
 
     @OutputFile
@@ -310,6 +325,22 @@ public class ProGuard extends AbstractBaseTask {
         @NotNull final File baseCfgFile = getBaseCfgFile();
         startSection(conf, "Appending from " + baseCfgFile);
         conf.append(FileUtils.read(baseCfgFile));
+
+        if (isSerializationSupport()) {
+            startSection(conf, "Serialization support");
+            conf.append(
+                "-keepnames class * implements java.io.Serializable\n" +
+                "-keepclassmembers class * implements java.io.Serializable {\n" +
+                "    static final long serialVersionUID;\n" +
+                "    private static final java.io.ObjectStreamField[] serialPersistentFields;\n" +
+                "    !static !transient <fields>;\n" +
+                "    private void writeObject(java.io.ObjectOutputStream);\n" +
+                "    private void readObject(java.io.ObjectInputStream);\n" +
+                "    java.lang.Object writeReplace();\n" +
+                "    java.lang.Object readResolve();\n" +
+                "}"
+            );
+        }
 
         startSection(conf, "Shrinking & obfuscation flags");
         if (!isCustomisedBaseConfig()) {
@@ -567,5 +598,6 @@ public class ProGuard extends AbstractBaseTask {
         addConvention(CONVENTION_LOG_FILE, () -> resolvePathInBuildDir(out, "ProGuard.log"));
         addConvention(CONVENTION_MINIFY_ENABLED, ext.proguard::isMinifyEnabled);
         addConvention(CONVENTION_OBFUSCATION_ENABLED, ext.proguard::isObfuscationEnabled);
+        addConvention(CONVENTION_SERIALIZATION_SUPPORT, ext.proguard::isSerializationSupport);
     }
 }


### PR DESCRIPTION
Keeping all fields for serialization and the serialization related methods by default may create a unnecessary big overhead. Also it prevents some obfuscation steps for enums.
It is probably better to change it to a configurable feature that defaults to "false".

related pr: https://github.com/multi-os-engine/moe-core/pull/5